### PR TITLE
Fix to https://github.com/edgeprot/xflows/issues/2

### DIFF
--- a/pkg/outputs/kafka.go
+++ b/pkg/outputs/kafka.go
@@ -44,7 +44,7 @@ func NewKafkaOutput(config map[string]interface{}, level logrus.Level) (*KafkaOu
 func (k *KafkaOutput) Send(sample *sflow.SFlowSample) error {
 	data, err := json.Marshal(sample)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	return k.writer.WriteMessages(context.Background(), kafka.Message{Value: data})

--- a/pkg/sflow/parser.go
+++ b/pkg/sflow/parser.go
@@ -79,7 +79,7 @@ func (p *Parser) ParseEBPFData(data []byte) (*SFlowSample, error) {
 		PacketSize:  uint32(_totalLen),
 		Raw:         data[:_cutoff],
 
-		TOS:      uint8(_ipPacket[8]),
+		TOS:      uint8(_ipPacket[1]),
 		SrcIP:    net.IP(_ipPacket[12:16]),
 		DstIP:    net.IP(_ipPacket[16:20]),
 		Protocol: uint8(_ipPacket[9]),


### PR DESCRIPTION
Fixes #2:

sflow/parser.go L82: The intention was to grab TOS, I believe I looked at the wrong field while trying to grab the index for it, this has been updated and fixed.

outputs/kafka.go L47: This was a small oversight and has also been updated and fixed.